### PR TITLE
adds query for public profile

### DIFF
--- a/src/dataSources/cloudFirestore/member.js
+++ b/src/dataSources/cloudFirestore/member.js
@@ -53,6 +53,7 @@ const member = (dbInstance, logger) => {
     const docSnapshot = await membersCol
       .where('profileSlug', '==', slug.toLowerCase())
       .where('canFeature', '==', true)
+      .where('isDeactivated', '==', false)
       .get();
 
     let results = null;

--- a/src/dataSources/cloudFirestore/member.js
+++ b/src/dataSources/cloudFirestore/member.js
@@ -49,6 +49,27 @@ const member = (dbInstance, logger) => {
     };
   }
 
+  async function findMember(slug) {
+    const docSnapshot = await membersCol
+      .where('profileSlug', '==', slug.toLowerCase())
+      .where('canFeature', '==', true)
+      .get();
+
+    let results = null;
+
+    if (docSnapshot.size === 1) {
+      const profile = docSnapshot.docs[0].data();
+      profile.id = docSnapshot.docs[0].id;
+      profile.profileLinks = profile.profileLinks.filter(
+        pl => pl.isPublic === true,
+      );
+
+      results = profile;
+    }
+
+    return results;
+  }
+
   async function findMe(memberId) {
     const docRef = await dbInstance.doc(`${collectionName}/${memberId}`).get();
 
@@ -79,7 +100,7 @@ const member = (dbInstance, logger) => {
     };
   }
 
-  return { create, findMe, update, isProfileSlugTaken };
+  return { create, findMe, update, isProfileSlugTaken, findMember };
 };
 
 export default member;

--- a/src/graphql/resolvers/mutations/members.js
+++ b/src/graphql/resolvers/mutations/members.js
@@ -15,11 +15,15 @@ export const fieldResolvers = {
       { profile },
       { dataSources: { firestore, logger, postmark }, user },
     ) => {
+      const modifiedProfile = profile;
       dlog('MembersMutation:create %o', profile);
+
+      // set some default values.
+      modifiedProfile.isDeactivated = false;
 
       const memberProfile = await memberStore(firestore, logger).create({
         user,
-        profile,
+        modifiedProfile,
       });
 
       await postmark.sendEmailWithTemplate({

--- a/src/graphql/resolvers/queries/members.js
+++ b/src/graphql/resolvers/queries/members.js
@@ -7,6 +7,11 @@ const dlog = debug('that:api:members:query');
 
 export const fieldResolvers = {
   MembersQuery: {
+    member: async (_, { slug }, { dataSources: { firestore, logger } }) => {
+      dlog('member called');
+      return memberStore(firestore, logger).findMember(slug);
+    },
+
     me: async (parent, args, { dataSources: { firestore, logger }, user }) => {
       dlog('MembersQuery:me called');
       return memberStore(firestore, logger).findMe(user.sub);

--- a/src/graphql/typeDefs/dataTypes/profile.graphql
+++ b/src/graphql/typeDefs/dataTypes/profile.graphql
@@ -23,7 +23,7 @@ type Profile @key(fields: "id") {
   thatSlackUsername: String
 
   sessions: [Session]
-  isDeactived: Boolean
+  isDeactivated: Boolean!
 
   canFeature: Boolean!
   acceptedCodeOfConduct: Boolean

--- a/src/graphql/typeDefs/dataTypes/profileInput.graphql
+++ b/src/graphql/typeDefs/dataTypes/profileInput.graphql
@@ -48,6 +48,7 @@ input ProfileUpdateInput {
 
   acceptedCommitments: Boolean
   isOver18: Boolean!
+  isDeactivated: Boolean!
 
   canFeature: Boolean
 }

--- a/src/graphql/typeDefs/dataTypes/publicProfile.graphql
+++ b/src/graphql/typeDefs/dataTypes/publicProfile.graphql
@@ -1,0 +1,22 @@
+type PublicProfile @key(fields: "id") {
+  id: ID!
+
+  firstName: String!
+  lastName: String!
+  company: String
+  jobTitle: String
+  profileSlug: String! @lowerCase
+  profileImage: String
+  bio: String
+  interests: [String]
+  lifeHack: String
+  profileLinks: [ProfileLink]
+  thatSlackUsername: String
+  sessions: [Session]
+  createdAt: Date!
+  lastUpdatedAt: Date!
+}
+
+extend type Session @key(fields: "id") {
+  id: ID! @external
+}

--- a/src/graphql/typeDefs/queries/members.graphql
+++ b/src/graphql/typeDefs/queries/members.graphql
@@ -1,4 +1,5 @@
 type MembersQuery {
+  member(slug: String): PublicProfile
   me: Profile @auth(requires: "members")
   isProfileSlugTaken(slug: String!): Boolean @auth(requires: "members")
 }


### PR DESCRIPTION
Adds a query for any member who wasn't to be listed on our public pages. No authentication required and reduced schema to only that of public items.

example query

```
query getMe {
  members {
    member(slug: "csell5") {
      id
      firstName
      lastName
      company
      jobTitle
      profileSlug
      profileImage
      bio
      interests
      lifeHack
      profileLinks {
        isPublic
        linkType
        url
      }
      thatSlackUsername
      createdAt
      lastUpdatedAt
    }
  }
}
```