### PR TITLE
Add ability to sort by first name asc. 

### DIFF
--- a/src/graphql/resolvers/queries/members.js
+++ b/src/graphql/resolvers/queries/members.js
@@ -12,19 +12,20 @@ export const fieldResolvers = {
       { dataSources: { firestore } },
     ) => {
       dlog('resolver, MembersQuery, members, orderBy: %s', orderBy);
+      let result = {};
       if (!orderBy || orderBy === 'CREATEDBY') {
-        return memberStore(firestore).fetchPublicMembersByCreated(
+        result = memberStore(firestore).fetchPublicMembersByCreated(
           pageSize,
           after,
         );
       }
       if (orderBy === 'FIRSTNAME') {
-        return memberStore(firestore).fetchPublicMembersByFirstName(
+        result = memberStore(firestore).fetchPublicMembersByFirstName(
           pageSize,
           after,
         );
       }
-      return {};
+      return result;
     },
     member: (_, { slug }, { dataSources: { firestore } }) => {
       dlog('member called');

--- a/src/graphql/resolvers/queries/members.js
+++ b/src/graphql/resolvers/queries/members.js
@@ -6,9 +6,25 @@ const dlog = debug('that:api:members:query');
 
 export const fieldResolvers = {
   MembersQuery: {
-    members: (_, { pageSize = 20, after }, { dataSources: { firestore } }) => {
-      dlog('resolver, MembersQuery, members');
-      return memberStore(firestore).fetchPublicMember(pageSize, after);
+    members: (
+      _,
+      { pageSize = 20, after, orderBy },
+      { dataSources: { firestore } },
+    ) => {
+      dlog('resolver, MembersQuery, members, orderBy: %s', orderBy);
+      if (!orderBy || orderBy === 'CREATEDBY') {
+        return memberStore(firestore).fetchPublicMembersByCreated(
+          pageSize,
+          after,
+        );
+      }
+      if (orderBy === 'FIRSTNAME') {
+        return memberStore(firestore).fetchPublicMembersByFirstName(
+          pageSize,
+          after,
+        );
+      }
+      return {};
     },
     member: (_, { slug }, { dataSources: { firestore } }) => {
       dlog('member called');

--- a/src/graphql/typeDefs/dataTypes/enums/orderBy.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/orderBy.graphql
@@ -1,0 +1,4 @@
+enum OrderBy {
+  CREATEDAT
+  FIRSTNAME
+}

--- a/src/graphql/typeDefs/queries/members.graphql
+++ b/src/graphql/typeDefs/queries/members.graphql
@@ -7,5 +7,5 @@ type MembersQuery {
   isProfileSlugTaken(slug: String!): Boolean @auth(requires: "members")
 
   "Returns all members in decending order. Default count of 20, limit of 100 per request"
-  members(pageSize: Int, after: String): PagedMember
+  members(orderBy: OrderBy, pageSize: Int, after: String): PagedMember
 }

--- a/src/graphql/typeDefs/queries/members.graphql
+++ b/src/graphql/typeDefs/queries/members.graphql
@@ -2,10 +2,10 @@ type MembersQuery {
   "Returns a single member by slug"
   member(slug: String): PublicProfile
 
-  "Returns member based on auth"
+  "Returns member based on auth, logged in member"
   me: Profile @auth(requires: "members")
   isProfileSlugTaken(slug: String!): Boolean @auth(requires: "members")
 
-  "Returns all members in decending order. Default count of 20, limit of 100 per request"
+  "Returns all members. Defaults: count: 20, limit: 100, orderby: CREATEDAT"
   members(orderBy: OrderBy, pageSize: Int, after: String): PagedMember
 }


### PR DESCRIPTION
Firestore sorts are explicitly managed by indexes
A new function was chose for this sort for single responsibility principle due to the explicitness of Firebase `orderBy` and cursor-based paging.
