### PR TITLE
always insure member.interests exists

### DIFF
--- a/src/dataSources/cloudFirestore/member.js
+++ b/src/dataSources/cloudFirestore/member.js
@@ -12,8 +12,9 @@ function scrubProfile(profile, isNew) {
   if (isNew) {
     scrubbedProfile.createdAt = modifiedAtDate;
   }
-
   scrubbedProfile.lastUpdatedAt = modifiedAtDate;
+
+  if (!scrubbedProfile.interests) scrubbedProfile.interests = [];
 
   return scrubbedProfile;
 }


### PR DESCRIPTION
links to #73 

Updates all writes to datastore to ensure that interests exists and is at least `[]`. 

#73 will not be complete until existing records are updated. 