### PR TITLE
Add PulbicProfile sessions filter

### DIFF
--- a/src/graphql/resolvers/queries/publicProfile.js
+++ b/src/graphql/resolvers/queries/publicProfile.js
@@ -23,8 +23,6 @@ export const fieldResolvers = {
     ) => {
       dlog('sessions for %s with filter %s', id, filter);
 
-      let localFilter = 'UPCOMING';
-      if (filter) localFilter = filter;
       // today at 00:00:00.000 (in epoch number format)
       let parsableTime = new Date().setHours(0, 0, 0, 0);
       if (asOfDate) {
@@ -34,25 +32,29 @@ export const fieldResolvers = {
       const targetDate = new Date(parsableTime);
       dlog('as of date: %s', targetDate);
       let result;
-      if (localFilter === 'ALL') {
-        result = sessionStore(firestore).findMembersAcceptedSessions({
-          memberId: id,
-        });
-      } else if (localFilter === 'UPCOMING') {
-        result = sessionStore(firestore).findMembersAcceptedSessionsFromDate({
-          memberId: id,
-          fromDate: targetDate,
-        });
-      } else if (localFilter === 'PAST') {
-        result = sessionStore(firestore).findMembersAcceptedSessionsBeforeDate({
-          memberId: id,
-          beforeDate: targetDate,
-        });
-      } else
-        throw new Error(
-          'Unknown AcceptedSessionFilter value provided. %s',
-          filter,
-        );
+      switch (filter) {
+        case 'ALL':
+          result = sessionStore(firestore).findMembersAcceptedSessions({
+            memberId: id,
+          });
+          break;
+
+        case 'PAST':
+          result = sessionStore(
+            firestore,
+          ).findMembersAcceptedSessionsBeforeDate({
+            memberId: id,
+            beforeDate: targetDate,
+          });
+          break;
+
+        default:
+          // UPCOMING
+          result = sessionStore(firestore).findMembersAcceptedSessionsFromDate({
+            memberId: id,
+            fromDate: targetDate,
+          });
+      }
 
       return result;
     },

--- a/src/graphql/resolvers/queries/publicProfile.js
+++ b/src/graphql/resolvers/queries/publicProfile.js
@@ -16,11 +16,45 @@ export const fieldResolvers = {
       return user;
     },
     earnedMeritBadges: meritBadgesResolver.earnedMeritBadges,
-    sessions: ({ id }, __, { dataSources: { firestore } }) => {
-      dlog('sessions for %s', id);
-      return sessionStore(firestore).findMembersAcceptedSessions({
-        memberId: id,
-      });
+    sessions: (
+      { id },
+      { filter, asOfDate },
+      { dataSources: { firestore } },
+    ) => {
+      dlog('sessions for %s with filter %s', id, filter);
+
+      let localFilter = 'UPCOMING';
+      if (filter) localFilter = filter;
+      // today at 00:00:00.000 (in epoch number format)
+      let parsableTime = new Date().setHours(0, 0, 0, 0);
+      if (asOfDate) {
+        // dates from json are string formatted hopefully iso format
+        parsableTime = asOfDate;
+      }
+      const targetDate = new Date(parsableTime);
+      dlog('as of date: %s', targetDate);
+      let result;
+      if (localFilter === 'ALL') {
+        result = sessionStore(firestore).findMembersAcceptedSessions({
+          memberId: id,
+        });
+      } else if (localFilter === 'UPCOMING') {
+        result = sessionStore(firestore).findMembersAcceptedSessionsFromDate({
+          memberId: id,
+          fromDate: targetDate,
+        });
+      } else if (localFilter === 'PAST') {
+        result = sessionStore(firestore).findMembersAcceptedSessionsBeforeDate({
+          memberId: id,
+          beforeDate: targetDate,
+        });
+      } else
+        throw new Error(
+          'Unknown AcceptedSessionFilter value provided. %s',
+          filter,
+        );
+
+      return result;
     },
   },
 };

--- a/src/graphql/typeDefs/dataTypes/enums/acceptedSessionFilter.graphql
+++ b/src/graphql/typeDefs/dataTypes/enums/acceptedSessionFilter.graphql
@@ -1,0 +1,8 @@
+enum AcceptedSessionFilter {
+  "All sessions, no filtering"
+  ALL
+  "Sessions today and forward"
+  UPCOMING
+  "Session before today"
+  PAST
+}

--- a/src/graphql/typeDefs/dataTypes/publicProfile.graphql
+++ b/src/graphql/typeDefs/dataTypes/publicProfile.graphql
@@ -14,8 +14,8 @@ type PublicProfile @key(fields: "id") {
   "Social media and other member links"
   profileLinks: [ProfileLink]
   thatSlackUsername: String
-  "Member's accepted sessions"
-  sessions: [AcceptedSession]
+  "Member's accepted sessions. Defaults: Filter: UPCOMING, asOfDate: server date now @ 00:00:00.000"
+  sessions(filter: AcceptedSessionFilter, asOfDate: Date): [AcceptedSession]
   "Member's earned Merit Badges"
   earnedMeritBadges: [MeritBadge]
   "Date and time member created"


### PR DESCRIPTION
**First Pass with Filter**

Add PublicProfile `sessions` filter for `ALL`, `UPCOMING`, `PAST`.  Default is `UPCOMING`. Argument named `filter`
Add as of date for `sessions` filter. 
Both parameters are optional. 
`filter` will default to `UPCOMING`
`asOfDate` will default to server's date now @ 00:00:00.000 

**ordering**
Results ordered by `startTime`
`ALL`: ascending
`UPCOMING`: ascending
`PAST`: descending

**Note: having `PAST` return descending does cost us to have an additional index in Firestore.

I suggest sending the date with time set to zero from the client. This way we are getting the day in relation to the client's Timezone. Something like this will get the format needed for JSON, 
`new Date(new Date().setHours(0,0,0,0)).toISOString()`

If a variables object is used to set the date then the date will be in a parsable format when stringified. 
```
const v = {
  asOfDate: new Date(new Date().setHours(0,0,0,0)),
}
JSON.stringify(v)
```

The command `new Date().setHours(0,0,0,0)` returns an epoch number. This can't be passed in to the `asOfDate` parameter as GraphQL is expecting a date type and must be able to understand it as such (a string representation of a date). 


