### PR TITLE
fix issue when batch request is made with no values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "that-api-members",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "THATConference.com members service.",
   "main": "index.js",
   "engines": {

--- a/src/dataSources/cloudFirestore/member.js
+++ b/src/dataSources/cloudFirestore/member.js
@@ -186,6 +186,7 @@ const member = dbInstance => {
     const docRefs = memberIds.map(id =>
       dbInstance.doc(`${collectionName}/${id}`),
     );
+    if (docRefs.length < 1) return [];
 
     return dbInstance.getAll(...docRefs).then(docSnaps =>
       docSnaps.map(r => {


### PR DESCRIPTION
v2.9.1
It seems batchFIndMembers may be called with no id's. This causes an issue with `firestore.getAll()`, which is handled naturally by the old `promise.all()` way of batch requesting members. 